### PR TITLE
Add space between the type+colon and the length for better readability.

### DIFF
--- a/lib/indentation-indicator-view.coffee
+++ b/lib/indentation-indicator-view.coffee
@@ -29,7 +29,7 @@ class IndentationIndicatorView extends View
   # Returns the {String} containing the text for the indicator.
   formatText: (softTabs, length) ->
     type = if softTabs then "Spaces" else "Tabs"
-    "#{type}:#{length}"
+    "#{type}: #{length}"
 
   # Internal: Gets the currently active `Editor`.
   #


### PR DESCRIPTION
I'd like to suggest adding a space between the indent type+colon and the length. In my opinion it's easier on the eye, more readable.
- Spaces:2 # current
- Spaces: 2 # with this commit
